### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>6.0-r2604.2</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.3 (Fixed Apache HttpClient burning down the CPU)